### PR TITLE
Taskモデルを作成（タイトル・内容・期限・ユーザー・ボードの情報を保持）

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -3,15 +3,22 @@ class TasksController < ApplicationController
 
   def create
     @board = Board.find(params[:board_id])
-    @task = current_user.tasks.build(task_params)
-    @task.board = @board
+    @task = @board.tasks.build(task_params)
+    @task.user = current_user  # 投稿者を紐づける
 
     if @task.save
-      redirect_to board_path(@board), notice: 'タスクを作成しました'
+      redirect_to board_path(@board), notice: 'タスクを追加しました'
     else
-      redirect_to board_path(@board), alert: 'タスクの作成に失敗しました'
+      @tasks = @board.tasks.includes(:user)
+      render 'boards/show', status: :unprocessable_entity
     end
   end
+
+  def show
+    @board = Board.find(params[:board_id])  # ネストされたルーティングではこちら
+    @task = @board.tasks.find(params[:id])  # このタスクだけ表示
+  end
+
 
   private
 

--- a/app/views/boards/index.html.haml
+++ b/app/views/boards/index.html.haml
@@ -2,6 +2,7 @@
 
 - @boards.each do |board|
   .board-card
-    %h2= board.title
+    %h3
+      = link_to board.title, board_path(board)
     %p= board.content
     %p 投稿者：= board.user.email

--- a/app/views/boards/show.html.haml
+++ b/app/views/boards/show.html.haml
@@ -4,7 +4,7 @@
 %h3 タスク一覧
 - @tasks.each do |task|
   %div.task
-    %p= task.title
+    = link_to task.title, board_task_path(@board, task)
     %p= task.content
     %p 投稿者: #{task.user.email}
     %p 期限: #{task.deadline}
@@ -17,13 +17,17 @@
         - @task.errors.full_messages.each do |msg|
           %li= msg
 
-  = f.label :title, 'タイトル'
-  = f.text_field :title
+  .form-group
+    = f.label :title, 'タイトル'
+    = f.text_field :title, class: 'form-control'
 
-  = f.label :content, '内容'
-  = f.text_area :content
+  .form-group
+    = f.label :content, '内容'
+    = f.text_area :content, class: 'form-control'
 
-  = f.label :deadline, '期限'
-  = f.date_field :deadline
+  .form-group
+    = f.label :deadline, '期限'
+    = f.date_field :deadline, class: 'form-control'
 
   = f.submit '作成', class: 'btn btn-primary'
+

--- a/app/views/home/index.html.haml
+++ b/app/views/home/index.html.haml
@@ -6,7 +6,8 @@
   .cards-container
     - @latest_boards.each do |board|
       .authenticate-card
-        %h3= board.title
+        %h3
+          = link_to board.title, board_path(board)
         %p= board.content
         %p 作成者: #{board.user.email}
         = image_tag '/app/assets/images/profile_picture_common.jpeg'
@@ -14,6 +15,7 @@
         - if board.user == current_user
           = link_to '編集', edit_board_path(board), class: 'btn btn-outline-primary'
           = link_to '削除', board_path(board), method: :delete, data: { confirm: '本当に削除しますか？' }, class: 'btn btn-outline-danger'
+        
 
   = link_to '新規作成', new_board_path, class: 'btn-primary'
   = link_to 'ボード一覧へ', boards_path, class: 'btn-secondary'

--- a/app/views/tasks/show.html.haml
+++ b/app/views/tasks/show.html.haml
@@ -1,0 +1,7 @@
+%h2= @task.title
+
+%p= @task.content
+%p 投稿者: #{@task.user.email}
+%p 期限: #{@task.deadline}
+
+= link_to 'ボードに戻る', board_path(@board), class: 'btn btn-secondary'


### PR DESCRIPTION
モデル間のアソシエーションを設定（User, Boardと関連付け）
ボード詳細ページでタスクの一覧表示・新規追加フォームを実装
タスクの投稿者（current_user）を保存する処理を実装
タスク詳細ページ（show）を作成