### PR TITLE
タスク詳細ページ（＋コメント追加、編集ページ）をカードデザイン風に作成

### DIFF
--- a/app/assets/stylesheets/authenticate.scss
+++ b/app/assets/stylesheets/authenticate.scss
@@ -429,7 +429,184 @@
     color: #ddd;
 
     &:hover {
-      background-color: #e04c4c;
+      background-color: #da3535;
     }
   }
+}
+
+
+.task-detail-container {
+  width: 100%;
+  max-width: 1500px;
+  margin: 2rem auto;
+  padding: 1.5rem;
+  border: 1px solid #ddd;
+  border-radius: 10px;
+  background-color: #efefef;
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.05);
+  position: relative;
+}
+
+.task-detail-header {
+  position: relative;
+  padding: 12px 44px 0 44px;
+}
+
+  .task-detail-title {
+    font-size: 1.5rem;
+    font-weight: bold;
+    color: #333;
+    text-align: center;
+    margin: 0;
+  }
+
+  .task-detail-header .dropdown {
+  position: absolute;
+  top: 10px;
+  right: 12px;
+}
+
+.task-detail-header .dropdown .dropdown-menu {
+  position: absolute;
+  right: 0;
+  top: 26px;
+}
+
+  .task-detail-content {
+    margin-top: 1rem;
+    line-height: 1.6;
+  }
+
+  .task-detail-deadline {
+    margin-top: 1rem;
+
+    .deadline-label {
+      font-weight: bold;
+      margin-right: 0.3rem;
+    }
+  }
+
+  .task-detail-meta {
+    display: flex;
+    align-items: center;
+    margin-top: 1rem;
+    gap: 0.5rem;
+    color: #555;
+  }
+
+
+.task-detail-comments{
+  width: 100%;
+  max-width: 1500px;
+  margin: 2rem auto;
+  padding: 0 1.5rem;
+}
+
+.task-detail--comment-card{
+  background: #efefef;
+  border: 1px solid #ddd;
+  border-radius: 8px;
+  padding: 1rem;
+  margin-bottom: 1rem;
+  width: 100%;
+  max-width: 1500px;
+  margin-left: 0;
+  margin-right: 0;
+  position: relative;
+}
+
+.task-detail--comment-meta{
+  display: flex;
+  align-items: center;
+  gap: .5rem;
+  margin-bottom: .3rem;
+
+  .avatar{ width: 40px; height: 40px; border-radius: 50%; }
+  .nickname{ font-weight: 600; }
+  .timestamp{ margin-left: auto; font-size: .8rem; color: gray; }
+}
+
+/* コメントカード右上の三点メニュー配置 */
+.task-detail--comment-card .dropdown{
+  position: absolute;
+  top: 8px;
+  right: 8px;
+}
+.task-detail--comment-card .dropdown .dropdown-menu{
+  position: absolute;
+  right: 0;
+  top: 26px; /* アイコンの高さ分下げる */
+}
+
+  .nickname {
+    font-weight: bold;
+  }
+
+  .timestamp {
+    font-size: 0.8rem;
+    color: gray;
+    margin-left: auto;
+  }
+
+
+.task-detail--comment-content {
+  margin-left: 48px; // アバターと揃える
+}
+
+
+.task-detail-actions {
+  position: absolute;
+  top: 12px;
+  right: 16px;
+}
+
+.task-detail-actions .dropbtn {
+  width: 30px;
+  height: 30px;
+  cursor: pointer;
+  display: block;
+}
+
+.btn-success {
+  border: none;
+  outline: none;
+}
+
+form .field {
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 1rem; /* ラベルと次の要素の余白 */
+}
+
+
+.comment-form-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center; /* 横中央 */
+  justify-content: center; /* 縦中央（必要に応じて） */
+  width: 100%;
+}
+
+.comment-form {
+  width: 100%;
+  max-width: 1200px;
+}
+
+.comment-form textarea.form-control {
+  width: 100% !important;
+  min-height: 140px;
+}
+
+.comment-form .form-actions .btn {
+  font-size: 16px;
+  border: none;
+  outline: none;
+  box-shadow: none;
+}
+
+.btn-primary,
+.btn-success {
+  border: none;
+  outline: none;
+  box-shadow: none; /* 黒い影も消す */
 }

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,4 +1,23 @@
 class CommentsController < ApplicationController
+  before_action :set_task
+  before_action :set_comment, only: [:edit, :update, :destroy]
+  before_action :authorize_owner!, only: [:edit, :update, :destroy]
+
+  def edit; end
+
+  def update
+    if @comment.update(comment_params)
+      redirect_to board_task_path(@task.board, @task), notice: 'コメントを更新しました。'
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    @comment.destroy
+    redirect_to board_task_path(@task.board, @task), notice: 'コメントを削除しました。'
+  end
+
   def new
     task = Task.find(params[:task_id])
     @comment = task.comments.build
@@ -17,7 +36,18 @@ class CommentsController < ApplicationController
     end
   end
 
-  private
+    private
+  def set_task
+    @task = Task.find(params[:task_id])
+  end
+
+  def set_comment
+    @comment = @task.comments.find(params[:id])
+  end
+
+  def authorize_owner!
+    redirect_to board_task_path(@task.board, @task), alert: '権限がありません' unless @comment.user == current_user
+  end
 
   def comment_params
     params.require(:comment).permit(:content)

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -19,7 +19,7 @@ class TasksController < ApplicationController
   def show
     @board = Board.find(params[:board_id])
     @task  = @board.tasks.find(params[:id])
-    @comments = @task.comments.includes(:user).order(created_at: :desc)
+    @comments = @task.comments.order(created_at: :asc) 
   end
 
   # GET /boards/:board_id/tasks/:id/edit

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -27,4 +27,11 @@ class Task < ApplicationRecord
 
   validates :title, presence: true   # タイトルが必須
   validates :content, presence: true # コンテンツ（概要）が必須
+
+  def show
+    @board = Board.find(params[:board_id])
+    @task = @board.tasks.find(params[:id])
+    @comments = @task.comments.order(created_at: :asc)
+  end
+
 end

--- a/app/views/boards/show.html.haml
+++ b/app/views/boards/show.html.haml
@@ -77,7 +77,7 @@
         = f.submit '作成', class: 'btn btn-success mt-2'
 
   .card-footer
-    = link_to 'Board一覧',
+    = link_to 'ボード一覧',
       root_path,
       class: 'btn-primary'
 

--- a/app/views/comments/_form.html.haml
+++ b/app/views/comments/_form.html.haml
@@ -1,0 +1,17 @@
+.authenticate-page-task
+  .task-detail-container
+    .comment-form-container
+      = form_with model: [@task, @comment], local: true,
+                  html: { class: 'comment-form' } do |f|
+        - if @comment.errors.any?
+          .alert.alert-danger
+            %ul
+              - @comment.errors.full_messages.each do |msg|
+                %li= msg
+
+        .form-group
+          = f.text_area :content, rows: 6, class: 'form-control'
+
+        .form-actions{ style: "margin-top: 12px; display:flex; gap:8px; justify-content:center;" }
+          = f.submit (@comment.new_record? ? '投稿' : '更新'), class: 'btn btn-primary'
+          = link_to 'キャンセル', board_task_path(@task.board, @task), class: 'btn btn-primary'

--- a/app/views/comments/edit.html.haml
+++ b/app/views/comments/edit.html.haml
@@ -1,0 +1,4 @@
+/ app/views/comments/edit.html.haml
+.authenticate-page-task
+  .auth-title-task コメント編集
+= render 'form'

--- a/app/views/comments/new.html.haml
+++ b/app/views/comments/new.html.haml
@@ -1,11 +1,3 @@
-.container
-  %ul
-    - @comment.errors.full_messages.each do |message|
-      %li= message
-
-  = form_with(model: @comment, url: task_comments_path(@comment.task), local: true) do |f|
-    %div
-      = f.label :content, '内容'
-    %div
-      = f.text_area :content
-    = f.submit '保存', class: 'btn-primary'
+.authenticate-page-task
+  .auth-title-task コメント追加
+= render 'form'

--- a/app/views/home/index.html.haml
+++ b/app/views/home/index.html.haml
@@ -1,6 +1,6 @@
 .authenticate-page
   .auth-title
-    Bord Todo App
+    Board Todo App
 
     / ===== 右上グローバルメニュー（タイトル帯の中に配置） =====
     .global-menu.dropdown{ data: { controller: "dropdown" } }
@@ -11,7 +11,7 @@
         data: { action: "click->dropdown#toggle" }
 
       .dropdown-menu.hidden{ data: { dropdown_target: "menu" } }
-        = link_to '新規作成', new_board_path
+        = link_to '新規ボード作成', new_board_path
         = link_to 'ボード一覧', boards_path
         = link_to 'プロフィール編集', edit_profile_path
         - unless user_signed_in?

--- a/app/views/tasks/edit.html.haml
+++ b/app/views/tasks/edit.html.haml
@@ -1,4 +1,4 @@
-%h2 タスクを編集
+%h2 タスク編集
 = form_with model: [@board, @task], local: true do |f|
   - if @task.errors.any?
     #error_explanation

--- a/app/views/tasks/show.html.haml
+++ b/app/views/tasks/show.html.haml
@@ -1,28 +1,72 @@
-%h2= @task.title
+.authenticate-page-task
+  .auth-title-task
+    タスク詳細
 
-%p= @task.content
-%p 投稿者: #{@task.user.email}
-%p 期限: #{@task.deadline}
-= image_tag current_user.avatar_image
+  .task-detail-container
+    .task-detail-header
+      %h2.task-detail-title= @task.title
+
+      - if user_signed_in? && @task.user == current_user
+        .dropdown{ data: { controller: "dropdown" } }
+          = image_tag 'actions.svg',
+            class: 'dropbtn',
+            alt: 'Actions',
+            data: { action: "click->dropdown#toggle", cardlink_ignore: true }
+          .dropdown-menu.hidden{ data: { dropdown_target: "menu" } }
+            = link_to '編集',  edit_board_task_path(@board, @task), data: { cardlink_ignore: true }
+            = link_to '削除',
+              board_task_path(@board, @task),
+              method: :delete,
+              data: { turbo_confirm: '本当に削除してもよろしいですか？', cardlink_ignore: true }
+
+    .task-detail-content
+      = simple_format(@task.content)
+
+    .task-detail-deadline
+      - if @task.deadline.present?
+        %span.deadline-label 期限:
+        %span= l(@task.deadline, format: :long)
+      - else
+        %span.deadline-label 期限:
+        %span 未設定
+
+    .task-detail-meta
+      = image_tag @task.user.avatar_url, class: 'avatar avatar--sm', alt: 'Task owner'
+      %span= @task.user.profile&.nickname.presence || @task.user.email.split('@').first
 
 
-- if @task.eyecatch.attached?
-  = image_tag @task.eyecatch, class: 'task-eyecatch'
 
-.task_content
-  = @task.content
-.task_heart
-  = image_tag 'heart.svg'
-
-.container
-
-
-.task
+  .task-detail-comments
   %h3 コメント一覧
-  - @comments.each do |comment|
-    %p= comment.content
-    %p= "投稿者: #{comment.user.email}"
 
-= link_to 'コメントを追加', new_task_comment_path(@task)
+  - if @comments.present?
+    - @comments.each do |comment|
+      .task-detail--comment-card
+        .task-detail--comment-meta
+          = image_tag comment.user.avatar_url, class: 'avatar avatar--sm', alt: 'Comment user'
+          %span.nickname= comment.user.profile&.nickname.presence || comment.user.email.split('@').first
+          %div.timestamp= l(comment.created_at, format: :short)
 
-= link_to 'タスク一覧に戻る', board_path(@board), class: 'btn btn-secondary'
+          - if user_signed_in? && comment.user == current_user
+            .dropdown{ data: { controller: "dropdown" } }
+              = image_tag 'actions.svg',
+                class: 'dropbtn',
+                alt: 'Actions',
+                data: { action: "click->dropdown#toggle", cardlink_ignore: true }
+              .dropdown-menu.hidden{ data: { dropdown_target: "menu" } }
+                = link_to '編集',  edit_task_comment_path(@task, comment), data: { cardlink_ignore: true }
+                = link_to '削除',
+                  task_comment_path(@task, comment),
+                  method: :delete,
+                  data: { turbo_confirm: '本当に削除しますか？', cardlink_ignore: true }
+
+
+        .task-detail--comment-content
+          = simple_format(comment.content)
+  - else
+    %p コメントはまだありません。
+
+  .comment-actions
+    = link_to 'コメント追加', new_task_comment_path(@task), class: 'btn btn-primary'
+    = link_to 'タスク一覧に戻る', board_path(@board), class: 'btn btn-primary'
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ Rails.application.routes.draw do
   end
 
   resources :tasks do
-    resources :comments, only: [:new, :create]
+    resources :comments, only: [:new, :create, :edit, :update, :destroy]
   end
 
   resource :profile, only: [:show, :edit, :update]


### PR DESCRIPTION
●残りやること
ー タスク作成者のみ編集可能な編集ページのデザイン調整
ー ボード一覧ページのデザイン調整
ー プロフィール編集ページのデザイン調整（アバター画像の保存機能？）
ー プロフィール画面の編集
ー ユーザ認証機能を独自で作成？してしまったため、railsのdevise機能に合わせる？