### PR TITLE
タスク作成者のみ編集可能な編集ページのデザイン調整

### DIFF
--- a/app/assets/stylesheets/authenticate.scss
+++ b/app/assets/stylesheets/authenticate.scss
@@ -393,6 +393,10 @@
   padding: 16px;
   border: 1px solid #ddd;
   border-radius: 8px;
+  width: 100%;
+  max-width: 1200px;
+  margin: 2rem auto;
+  box-sizing: border-box;
 
   .form-group {
     margin-bottom: 12px;
@@ -417,6 +421,7 @@
     display: flex;
     justify-content: center;
     margin-top: 16px;
+    gap: 12px; 
   }
 
   .btn-success {

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -59,6 +59,11 @@ class TasksController < ApplicationController
     redirect_to board_task_path(@board, @task), alert: '権限がありません' unless @task.user == current_user
   end
 
+  def authorize_task_owner!
+    return if current_user == @task.user
+    redirect_to board_task_path(@board, @task), alert: 'このタスクを編集する権限がありません。'
+  end
+
   def task_params
     params.require(:task).permit(:title, :content, :deadline, :eyecatch)
   end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -28,10 +28,5 @@ class Task < ApplicationRecord
   validates :title, presence: true   # タイトルが必須
   validates :content, presence: true # コンテンツ（概要）が必須
 
-  def show
-    @board = Board.find(params[:board_id])
-    @task = @board.tasks.find(params[:id])
-    @comments = @task.comments.order(created_at: :asc)
-  end
 
 end

--- a/app/views/tasks/_form.html.haml
+++ b/app/views/tasks/_form.html.haml
@@ -1,0 +1,27 @@
+.board-task-form
+  = form_with model: [@board, @task], local: true do |f|
+    - if @task.errors.any?
+      .alert.alert-danger
+        %ul
+          - @task.errors.full_messages.each do |msg|
+            %li= msg
+
+    .form-group
+      = f.label :title, 'タイトル'
+      = f.text_field :title, class: 'form-control'
+
+    .form-group
+      = f.label :content, '内容'
+      = f.text_area :content, class: 'form-control'
+
+    .form-group
+      = f.label :deadline, '期限'
+      = f.date_field :deadline, class: 'form-control'
+
+    .form-group
+      = f.label :eyecatch, '添付画像'
+      = f.file_field :eyecatch, class: 'form-control'
+
+    .form-actions
+      = f.submit (local_assigns[:submit_label] || '作成'), class: 'btn btn-success'
+      = link_to 'キャンセル', (local_assigns[:cancel_path] || board_path(@board)), class: 'btn btn-primary'

--- a/app/views/tasks/edit.html.haml
+++ b/app/views/tasks/edit.html.haml
@@ -1,29 +1,8 @@
-%h2 タスク編集
-= form_with model: [@board, @task], local: true do |f|
-  - if @task.errors.any?
-    #error_explanation
-      %ul
-        - @task.errors.full_messages.each do |msg|
-          %li= msg
+.authenticate-page-task
+  .auth-title-task
+    タスク編集
 
-  .form-group
-    = f.label :title, 'タイトル'
-    = f.text_field :title, class: 'form-control'
+  = render 'form',
+      submit_label: '更新',
+      cancel_path: board_task_path(@board, @task)
 
-  .form-group
-    = f.label :content, '内容'
-    = f.text_area :content, class: 'form-control'
-
-  .form-group
-    = f.label :deadline, '期限'
-    = f.date_field :deadline, class: 'form-control'
-
-  .form-group
-    = f.label :eyecatch, 'アイキャッチ画像'
-    - if @task.eyecatch.attached?
-      %p 現在の画像
-      = image_tag @task.eyecatch, class: 'task-eyecatch'
-    = f.file_field :eyecatch, class: 'form-control'
-
-  = f.submit '更新', class: 'btn btn-primary'
-  = link_to 'キャンセル', board_task_path(@board, @task), class: 'btn btn-secondary'


### PR DESCRIPTION
●残りやること
ー ボード一覧ページのデザイン調整
ー プロフィール編集ページのデザイン調整（アバター画像の保存機能？）
ー プロフィール画面の編集
ー ユーザ認証機能を独自で作成？してしまったため、railsのdevise機能に合わせる？