### PR TITLE
リファクタリング: 重複コードの整理・バグ修正・認証の全ページ適用

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,10 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(bin/dev)",
+      "Bash(lsof -ti:3000)",
+      "Bash(xargs kill -9)",
+      "WebFetch(domain:sheer-dugong-249.notion.site)"
+    ]
+  }
+}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,17 @@
 class ApplicationController < ActionController::Base
   allow_browser versions: :modern
+  before_action :authenticate_user!, unless: :devise_controller?
+
+  private
+
+  def setup_pagination(default_per_page: 10)
+    @per_page = params[:per_page].presence&.to_i || default_per_page
+    @per_page = default_per_page if @per_page <= 0
+    @page     = [params[:page].to_i, 1].max
+  end
+
+  def paginate(scope)
+    @total_pages = (scope.count / @per_page.to_f).ceil
+    scope.offset((@page - 1) * @per_page).limit(@per_page)
+  end
 end

--- a/app/controllers/boards_controller.rb
+++ b/app/controllers/boards_controller.rb
@@ -1,26 +1,14 @@
 class BoardsController < ApplicationController
-  before_action :authenticate_user!, only: %i[new create edit update destroy]
-  before_action :set_board,    only: [:edit, :update, :destroy]
-  before_action :correct_user, only: [:edit, :update, :destroy]
+  before_action :set_board,      only: [:show, :edit, :update, :destroy]
+  before_action :authorize_owner!, only: [:edit, :update, :destroy]
 
   def index
-    per_page = params[:per_page].presence&.to_i
-    per_page = Board.count if per_page.nil? || per_page <= 0
-
-    @page = params[:page].to_i
-    @page = 1 if @page < 1
-
     @boards = Board
       .includes(
         user: { avatar_attachment: :blob },
         tasks: [:user, { comments: :user }]
       )
       .order(created_at: :desc)
-      .offset((@page - 1) * per_page)
-      .limit(per_page)
-
-    @total_pages = (Board.count / per_page.to_f).ceil
-    @per_page    = per_page
   end
 
   def new
@@ -48,8 +36,7 @@ class BoardsController < ApplicationController
   end
 
   def show
-    @board = Board.find(params[:id])
-    @tasks = @board.tasks.includes(:user).order(Arel.sql("CASE WHEN deadline IS NULL THEN 1 ELSE 0 END, deadline ASC"))
+    @tasks = @board.tasks.includes(:user).ordered_by_deadline
     @task  = Task.new
   end
 
@@ -59,6 +46,7 @@ class BoardsController < ApplicationController
   end
 
   private
+
   def board_params
     params.require(:board).permit(:title, :content)
   end
@@ -67,7 +55,7 @@ class BoardsController < ApplicationController
     @board = Board.find(params[:id])
   end
 
-  def correct_user
+  def authorize_owner!
     redirect_to root_path, alert: '権限がありません' unless @board.user == current_user
   end
 end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,5 +1,4 @@
 class CommentsController < ApplicationController
-  before_action :authenticate_user!
   before_action :set_task
   before_action :set_comment, only: [:edit, :update, :destroy]
   before_action :authorize_owner!, only: [:edit, :update, :destroy]

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,13 +1,8 @@
 class HomeController < ApplicationController
   def index
-    per_page = params[:per_page].presence&.to_i || 5
-    per_page = 5 if per_page <= 0
+    setup_pagination(default_per_page: 5)
 
-    # ページ番号（1始まり）
-    @page = params[:page].to_i
-    @page = 1 if @page < 1
-
-    @latest_boards =
+    @latest_boards = paginate(
       Board
         .includes(
           user:  [ avatar_attachment: :blob ],
@@ -19,10 +14,6 @@ class HomeController < ApplicationController
           ]
         )
         .order(created_at: :desc)
-        .offset((@page - 1) * per_page)
-        .limit(per_page)
-
-    @total_pages = (Board.count / per_page.to_f).ceil
-    @per_page    = per_page
+    )
   end
 end

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -1,5 +1,4 @@
 class ProfilesController < ApplicationController
-  before_action :authenticate_user!
   before_action :set_profile
 
   def show; end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,5 +1,4 @@
 class TasksController < ApplicationController
-  before_action :authenticate_user!
   before_action :set_board
   before_action :set_task, only: [:show, :edit, :update, :destroy]
   before_action :authorize_owner!, only: [:edit, :update, :destroy]

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,26 @@
 module ApplicationHelper
+  def deadline_display(deadline)
+    label = content_tag(:span, '期限:', class: 'deadline-label')
+    value = if deadline.present?
+      css = if deadline < Date.current
+        'deadline-overdue'
+      elsif deadline == Date.current
+        'deadline-today'
+      end
+      content_tag(:span, l(deadline, format: :long), class: css)
+    else
+      content_tag(:span, '未設定')
+    end
+    label + value
+  end
+
+  def profile_avatar_url(profile)
+    if profile.avatar.attached?
+      url_for(profile.avatar)
+    elsif profile.user.avatar&.attached?
+      url_for(profile.user.avatar.variant(resize_to_fill: [80, 80]).processed)
+    else
+      asset_path('default-avatar.png')
+    end
+  end
 end

--- a/app/javascript/controllers/hello_controller.js
+++ b/app/javascript/controllers/hello_controller.js
@@ -1,7 +1,0 @@
-import { Controller } from "@hotwired/stimulus"
-
-export default class extends Controller {
-  connect() {
-    this.element.textContent = "Hello World!"
-  }
-}

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -3,26 +3,11 @@ class Profile < ApplicationRecord
   has_one_attached :avatar
   enum :gender, { male: 0, female: 1, other: 2 }
 
-
-  # 年齢（生年月日未設定なら "不明"）
   def age
     return '不明' unless birthday.present?
     today = Date.current
     years = today.year - birthday.year
-    years -= 1 if today.yday < birthday.yday
+    years -= 1 if today < birthday.change(year: today.year)
     years
   end
-
-  include Rails.application.routes.url_helpers
-
-  def avatar_url
-    if avatar.attached?
-      rails_blob_url(avatar, host: Rails.application.routes.default_url_options[:host])
-    elsif user.respond_to?(:avatar_url) && user.avatar_url.present?
-      user.avatar_url
-    else
-      ActionController::Base.helpers.asset_path('default-avatar.png')
-    end
-  end
-
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -23,11 +23,14 @@ class Task < ApplicationRecord
   belongs_to :board
 
   has_many :comments, dependent: :destroy
-  
+
   has_one_attached :eyecatch
 
-  validates :title, presence: true   # タイトルが必須
-  validates :content, presence: true # コンテンツ（概要）が必須
-  validates :priority, inclusion: { in: %w[high medium low], allow_blank: true }
+  scope :ordered_by_deadline, -> {
+    order(Arel.sql("CASE WHEN deadline IS NULL THEN 1 ELSE 0 END, deadline ASC"))
+  }
 
+  validates :title,    presence: true
+  validates :content,  presence: true
+  validates :priority, inclusion: { in: %w[high medium low], allow_blank: true }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,4 @@
 class User < ApplicationRecord
-  # Include default devise modules. Others available are:
-  # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   delegate :birthday, :age, :gender, :introduction, to: :profile, allow_nil: true
 
   has_many :boards, dependent: :destroy
@@ -21,15 +19,7 @@ class User < ApplicationRecord
   end
 
   def display_name
-    profile&.nickname || self.email.split('@').first
-  end
-
-  def avatar_image
-    if profile&.avatar&.attached?
-      profile.avatar
-    else
-      'default-avatar.png'
-    end
+    profile&.nickname.presence || email.split('@').first
   end
 
   def avatar_url(size: [28, 28])

--- a/app/views/boards/index.html.haml
+++ b/app/views/boards/index.html.haml
@@ -1,6 +1,3 @@
--# =========================================================
--#  ボード新規作成ページ
--# =========================================================
 .authenticate-page-task
   .auth-title-task
     ボード一覧
@@ -12,26 +9,17 @@
         %h3.board-card__title
           = link_to board.title, board_path(board), class: 'board-link'
 
-        -# ▼ 三点メニューを出す
-        - if user_signed_in? && board.user == current_user
-          .dropdown{ data: { controller: "dropdown" } }
-            = image_tag 'actions.svg',
-              class: 'dropbtn',
-              alt: 'Actions',
-              data: { action: "click->dropdown#toggle", cardlink_ignore: true }
-            .dropdown-menu.hidden{ data: { dropdown_target: "menu" } }
-              = link_to '編集', edit_board_path(board), data: { cardlink_ignore: true }
-              = link_to '削除',
-                board_path(board),
-                method: :delete,
-                data: { turbo_confirm: '本当に削除してもよろしいですか？', cardlink_ignore: true }
+        - if board.user == current_user
+          = render 'shared/dropdown_menu',
+              edit_path: edit_board_path(board),
+              delete_path: board_path(board)
 
       .board-card__body
         %p.board-card__description= board.content.presence || '説明なし'
 
       .board-card__meta
         = image_tag board.user.avatar_url, class: 'avatar avatar--sm', alt: 'Board owner', loading: 'lazy'
-        %span.nickname= board.user.profile&.nickname.presence || board.user.email.split('@').first
+        %span.nickname= board.user.display_name
 
         - count = board.tasks.size
         .board-card__tasks{ class: (count.zero? ? 'is-zero' : nil) }

--- a/app/views/boards/show.html.haml
+++ b/app/views/boards/show.html.haml
@@ -1,98 +1,40 @@
--# =========================================================
--#  ボード詳細 + タスク一覧 + タスク新規フォーム
--# =========================================================
 .authenticate-page-task
   .auth-title-task
     タスク一覧
 
-/ ▼ 全体を包むコンテナ
 .board-show-page
-  / ▼ Boardタイトルと概要
   .board-header
     %h2= @board.title
     %p.board-description= @board.content
 
-  / ▼ タスク一覧（最新順）
   .board-task-list
     - @tasks.each do |task|
       .task-card{ class: "priority-#{task.priority.presence || 'none'}" }
         .task-card__row
           = link_to task.title, board_task_path(@board, task), class: 'task-title'
 
-          -# 操作メニューを表示
-          - if user_signed_in? && task.user == current_user
-            .dropdown{ data: { controller: "dropdown" } }
-              = image_tag 'actions.svg',
-                class: 'dropbtn',
-                alt: 'Actions',
-                data: { action: "click->dropdown#toggle", cardlink_ignore: true }
-              .dropdown-menu.hidden{ data: { dropdown_target: "menu" } }
-                = link_to '編集',  edit_board_task_path(@board, task), data: { cardlink_ignore: true }
-                = link_to '削除',
-                  board_task_path(@board, task),
-                  method: :delete,
-                  data: { turbo_confirm: '本当に削除してもよろしいですか？', cardlink_ignore: true }
+          - if task.user == current_user
+            = render 'shared/dropdown_menu',
+                edit_path: edit_board_task_path(@board, task),
+                delete_path: board_task_path(@board, task)
 
         .task-card__content
           = simple_format(task.content)
 
         .task-card__deadline
-          - if task.deadline.present?
-            %span.deadline-label 期限:
-            - if task.deadline < Date.today
-              %span.deadline-overdue= l(task.deadline, format: :long)
-            - elsif task.deadline == Date.today
-              %span.deadline-today= l(task.deadline, format: :long)
-            - else
-              %span= l(task.deadline, format: :long)
-          - else
-            %span.deadline-label 期限:
-            %span 未設定
+          = deadline_display(task.deadline)
 
         .task-card__meta
-          -# アバターは nil 対応。avatar_url を使う実装の場合は適宜ヘルパー化推奨
-          - if task.user&.respond_to?(:avatar_url) && task.user.avatar_url.present?
-            = image_tag task.user.avatar_url, class: 'avatar avatar--sm', alt: 'Task owner', loading: 'lazy'
-          %span= task.user&.profile&.nickname.presence || task.user&.email&.split('@')&.first
+          = image_tag task.user.avatar_url, class: 'avatar avatar--sm', alt: 'Task owner', loading: 'lazy'
+          %span= task.user.display_name
 
-        -# コメント数表示（0のときは .is-zero で非表示）
         - count = task.comments.size
         .task-card__comments{ class: (count.zero? ? 'is-zero' : nil) }
           = image_tag 'comment.svg', alt: 'Comments', width: 32, height: 32, loading: 'lazy'
           %span= count
 
-  / ▼ 新規投稿フォーム（このページ内でタスクを追加）
   %h3#new-task タスクを追加
-  .board-task-form
-    = form_with model: [@board, @task], local: true do |f|
-      - if @task.errors.any?
-        .alert.alert-danger
-          %ul
-            - @task.errors.full_messages.each do |msg|
-              %li= msg
-
-      .form-group
-        = f.label :title, 'タイトル'
-        = f.text_field :title, class: 'form-control'
-
-      .form-group
-        = f.label :content, '内容'
-        = f.text_area :content, class: 'form-control'
-
-      .form-group
-        = f.label :deadline, '期限'
-        = f.date_field :deadline, class: 'form-control'
-
-      .form-group
-        = f.label :priority, '重要度'
-        = f.select :priority, [['高', 'high'], ['中', 'medium'], ['低', 'low']], { include_blank: '未設定' }, class: 'form-control'
-
-      .form-group
-        = f.label :eyecatch, '添付画像'
-        = f.file_field :eyecatch, class: 'form-control'
-
-      .form-actions
-        = f.submit '作成', class: 'btn btn-success mt-2'
+  = render 'tasks/form'
 
   .card-footer
     = link_to 'トップページに戻る', root_path, class: 'btn-primary'

--- a/app/views/home/index.html.haml
+++ b/app/views/home/index.html.haml
@@ -2,7 +2,6 @@
   .auth-title
     %h1.auth-title__text Board Todo App
 
-    -# ドロップダウンメニュー
     .global-menu.dropdown{ data: { controller: "dropdown" } }
       = image_tag "menu.svg",
         class: "menu-btn",
@@ -13,25 +12,21 @@
         = link_to 'ボード新規作成', new_board_path
         = link_to 'ボード一覧', boards_path
         = link_to 'プロフィールページ', profile_path
-        - if user_signed_in?
-          = link_to 'ログアウト', destroy_user_session_path, method: :delete, data: { turbo: false }, class: 'btn'
-        - else
-          = link_to 'ログイン / 新規ユーザー登録', new_user_session_path, class: 'btn'
+        = link_to 'ログアウト', destroy_user_session_path, method: :delete, data: { turbo: false }, class: 'btn'
 
   .cards-container
     - @latest_boards.each do |board|
       .authenticate-card{
         data: {
           controller: "cardlink",
-          cardlink_url_value: (user_signed_in? ? board_path(board) : new_user_session_path),
+          cardlink_url_value: board_path(board),
           action: "click->cardlink#go keydown->cardlink#key"
         },
         role: "link",
         tabindex: 0
       }
 
-        -# ボード見出し（タイトル + ユーザーアバター）
-        = link_to (user_signed_in? ? board_path(board) : new_user_session_path), class: 'board-head-link', data: { cardlink_ignore: true } do
+        = link_to board_path(board), class: 'board-head-link', data: { cardlink_ignore: true } do
           .board-head
             %span.board-label= board.title
             = image_tag board.user.avatar_url,
@@ -39,79 +34,46 @@
               alt: 'Board owner',
               loading: 'lazy', width: 24, height: 24
 
-        -# ボードの説明
         - if board.content.present?
           .board-description= board.content
 
         .task-list
           - if board.tasks.empty?
-            = link_to (user_signed_in? ? board_path(board) : new_user_session_path), class: 'task-empty-link', data: { cardlink_ignore: true } do
+            = link_to board_path(board), class: 'task-empty-link', data: { cardlink_ignore: true } do
               .task-empty
                 %p まだタスクがありません
           - else
-            - board.tasks.order(Arel.sql("CASE WHEN deadline IS NULL THEN 1 ELSE 0 END, deadline ASC")).each do |task|
+            - board.tasks.sort_by { |t| [t.deadline ? 0 : 1, t.deadline || Date.new(9999)] }.each do |task|
               .task-card{ class: "priority-#{task.priority.presence || 'none'}" }
                 .task-card__row
-                  -# タスクタイトル（ログイン済みなら詳細へ、未ログインならログイン画面へ）
-                  - if user_signed_in?
-                    = link_to task.title, board_task_path(board, task), class: 'task-title'
-                  - else
-                    = link_to task.title, new_user_session_path, class: 'task-title'
+                  = link_to task.title, board_task_path(board, task), class: 'task-title'
 
-                  -# 編集・削除ボタンを表示
-                  - if user_signed_in? && task.user == current_user
-                    .dropdown{ data: { controller: "dropdown" } }
-                      = image_tag 'actions.svg',
-                        class: 'dropbtn',
-                        alt: 'Actions',
-                        data: { action: "click->dropdown#toggle", cardlink_ignore: true }
-                      .dropdown-menu.hidden{ data: { dropdown_target: "menu" } }
-                        = link_to '編集',  edit_board_task_path(board, task), data: { cardlink_ignore: true }
-                        = link_to '削除',
-                          board_task_path(board, task),
-                          method: :delete,
-                          data: { turbo_confirm: '本当に削除しますか？', cardlink_ignore: true }
+                  - if task.user == current_user
+                    = render 'shared/dropdown_menu',
+                        edit_path: edit_board_task_path(board, task),
+                        delete_path: board_task_path(board, task),
+                        confirm_message: '本当に削除しますか？'
 
-                -# 期限が設定されている場合は表示
                 .task-card__deadline
-                  - if task.deadline.present?
-                    %span.deadline-label 期限:
-                    - if task.deadline < Date.today
-                      %span.deadline-overdue= l(task.deadline, format: :long)
-                    - elsif task.deadline == Date.today
-                      %span.deadline-today= l(task.deadline, format: :long)
-                    - else
-                      %span= l(task.deadline, format: :long)
+                  = deadline_display(task.deadline)
 
-                -# タスク作成者のアバター + 表示名（ニックネーム or メール）
                 .task-card__meta
                   = image_tag task.user.avatar_url, class: 'avatar avatar--sm', alt: 'Task owner', loading: 'lazy'
-                  %span= task.user.profile&.nickname.presence || task.user.email
+                  %span= task.user.display_name
 
-                -# コメント数を表示（0件のときは`is-zero`クラス付与）
                 - count = task.comments.size
                 .task-card__comments{ class: (count.zero? ? 'is-zero' : nil) }
                   = image_tag 'comment.svg', alt: 'Comments', width: 16, height: 16, loading: 'lazy'
                   %span= count
 
-        -# カード下部：+タスク追加ボタン（ログインしていれば表示）
         .card-footer
-          - if user_signed_in?
-            = link_to '+ タスク追加',
-              board_path(board, anchor: 'new-task'),
-              class: 'btn-primary',
-              data: { cardlink_ignore: true }
-          - else
-            = link_to 'ログインしてタスク追加',
-              new_user_session_path,
-              class: 'btn-primary',
-              data: { cardlink_ignore: true }
+          = link_to '+ タスク追加',
+            board_path(board, anchor: 'new-task'),
+            class: 'btn-primary',
+            data: { cardlink_ignore: true }
 
-  -# ページ送り（前へ）
   - if @page > 1
     = link_to '‹', root_path(page: @page - 1, per_page: @per_page), class: 'page-arrow page-arrow--left', aria_label: '前へ'
 
-  -# ページ送り（次へ）
   - if @page < @total_pages
     = link_to '›', root_path(page: @page + 1, per_page: @per_page), class: 'page-arrow page-arrow--right', aria_label: '次へ'
-

--- a/app/views/profiles/edit.html.haml
+++ b/app/views/profiles/edit.html.haml
@@ -2,25 +2,21 @@
   .auth-title-task
     プロフィール編集
 
--# フォーム全体を囲むコンテナ
 .board-form-container
   .board-form-card{ data: { controller: 'avatar-preview' } }
 
-    -# バリデーションエラーがある場合はアラート表示
     - if @profile.errors.any?
       .alert.alert-danger
         - @profile.errors.full_messages.each do |msg|
           %div= msg
 
-    -# 現在のアバター画像を表示
     .current-avatar
       %label 現在のアバター画像
-      = image_tag @profile.avatar_url,
+      = image_tag profile_avatar_url(@profile),
                   class: 'profile-avatar preview-target',
                   alt: '現在のアバター',
                   loading: 'lazy'
 
-    -# プロフィール編集用のフォーム
     = form_with model: @profile, url: profile_path, method: :put, local: true do |f|
       .form-group
         = f.label :avatar, '新しいアバター画像'

--- a/app/views/profiles/show.html.haml
+++ b/app/views/profiles/show.html.haml
@@ -2,24 +2,20 @@
   .auth-title-task
     プロフィールページ
 
--# プロフィールの表示用コンテナ
 .board-form-container
   .board-form-card
 
-    -# プロフィールのヘッダー（アバター・名前・年齢・性別）
     .profile-card_header
-      = image_tag @profile.avatar_url,
+      = image_tag profile_avatar_url(@profile),
                   class: 'profile-avatar',
                   alt: 'Avatar',
                   loading: 'lazy'
 
-      - display_name = @profile.nickname.presence || @profile.user.email.split('@').first
-      - age_text = @profile.age
+      %h3= @profile.user.display_name
+      - age_text    = @profile.age
       - gender_text = (I18n.t("enum.genders.#{@profile.gender}") rescue '')
-      %h3= display_name
       %p= "#{age_text}歳・#{gender_text}"
 
-    -# メールや紹介文、生年月日の表示
     .profile-card_body
       .profile-row
         %label メール
@@ -35,7 +31,6 @@
         %span= @profile.birthday ? l(@profile.birthday) : '未設定'
 
     .profile-actions
-      -# ログインユーザー自身なら編集ボタンを表示
-      - if user_signed_in? && current_user == @profile.user
+      - if current_user == @profile.user
         = link_to '編集', edit_profile_path, class: 'btn btn-primary'
       = link_to 'トップページに戻る', root_path, class: 'btn btn-primary'

--- a/app/views/shared/_dropdown_menu.html.haml
+++ b/app/views/shared/_dropdown_menu.html.haml
@@ -1,0 +1,11 @@
+.dropdown{ data: { controller: "dropdown" } }
+  = image_tag 'actions.svg',
+    class: 'dropbtn',
+    alt: 'Actions',
+    data: { action: "click->dropdown#toggle", cardlink_ignore: true }
+  .dropdown-menu.hidden{ data: { dropdown_target: "menu" } }
+    = link_to '編集', edit_path, data: { cardlink_ignore: true }
+    = link_to '削除', delete_path,
+      method: :delete,
+      data: { turbo_confirm: (local_assigns[:confirm_message] || '本当に削除してもよろしいですか？'),
+              cardlink_ignore: true }

--- a/app/views/tasks/show.html.haml
+++ b/app/views/tasks/show.html.haml
@@ -6,18 +6,10 @@
     .task-detail-header
       %h2.task-detail-title= @task.title
 
-      - if user_signed_in? && @task.user == current_user
-        .dropdown{ data: { controller: "dropdown" } }
-          = image_tag 'actions.svg',
-            class: 'dropbtn',
-            alt: 'Actions',
-            data: { action: "click->dropdown#toggle", cardlink_ignore: true }
-          .dropdown-menu.hidden{ data: { dropdown_target: "menu" } }
-            = link_to '編集',  edit_board_task_path(@board, @task), data: { cardlink_ignore: true }
-            = link_to '削除',
-              board_task_path(@board, @task),
-              method: :delete,
-              data: { turbo_confirm: '本当に削除してもよろしいですか？', cardlink_ignore: true }
+      - if @task.user == current_user
+        = render 'shared/dropdown_menu',
+            edit_path: edit_board_task_path(@board, @task),
+            delete_path: board_task_path(@board, @task)
 
     .task-detail-content
       = simple_format(@task.content)
@@ -27,16 +19,11 @@
         = image_tag url_for(@task.eyecatch), class: 'task-eyecatch'
 
     .task-detail-deadline
-      - if @task.deadline.present?
-        %span.deadline-label 期限:
-        %span= l(@task.deadline, format: :long)
-      - else
-        %span.deadline-label 期限:
-        %span 未設定
+      = deadline_display(@task.deadline)
 
     .task-detail-meta
       = image_tag @task.user.avatar_url, class: 'avatar avatar--sm', alt: 'Task owner'
-      %span= @task.user.profile&.nickname.presence || @task.user.email.split('@').first
+      %span= @task.user.display_name
 
   .task-detail-comments
   %h3 コメント一覧
@@ -46,21 +33,14 @@
       .task-detail--comment-card
         .task-detail--comment-meta
           = image_tag comment.user.avatar_url, class: 'avatar avatar--sm', alt: 'Comment user'
-          %span.nickname= comment.user.profile&.nickname.presence || comment.user.email.split('@').first
+          %span.nickname= comment.user.display_name
           %div.timestamp= l(comment.created_at, format: :short)
 
-          - if user_signed_in? && comment.user == current_user
-            .dropdown{ data: { controller: "dropdown" } }
-              = image_tag 'actions.svg',
-                class: 'dropbtn',
-                alt: 'Actions',
-                data: { action: "click->dropdown#toggle", cardlink_ignore: true }
-              .dropdown-menu.hidden{ data: { dropdown_target: "menu" } }
-                = link_to '編集',  edit_task_comment_path(@task, comment), data: { cardlink_ignore: true }
-                = link_to '削除',
-                  task_comment_path(@task, comment),
-                  method: :delete,
-                  data: { turbo_confirm: '本当に削除しますか？', cardlink_ignore: true }
+          - if comment.user == current_user
+            = render 'shared/dropdown_menu',
+                edit_path: edit_task_comment_path(@task, comment),
+                delete_path: task_comment_path(@task, comment),
+                confirm_message: '本当に削除しますか？'
 
         .task-detail--comment-content
           = simple_format(comment.content)


### PR DESCRIPTION
- URL を開いた時点でログイン必須に変更し、認証を ApplicationController に一元化
- ページネーションロジックを ApplicationController の共通メソッドに切り出し
- ドロップダウンメニューを shared/_dropdown_menu パーシャルに共通化
- 期限表示ロジックを deadline_display ヘルパーに、アバターURL生成を profile_avatar_url ヘルパーに切り出し
- Task モデルに ordered_by_deadline スコープを追加し、ビュー内の生SQLを排除
- Profile#age の閏年バグを修正、Profile モデルから URL ヘルパーの include を削除
- 各ビューのユーザー表示名を display_name に統一、boards/show のフォームをパーシャル化
- 未使用の hello_controller.js および User#avatar_image メソッドを削除