### PR TITLE
テスト追加: Request Spec による認証・権限・CRUDのテストを追加

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -8,7 +8,9 @@
       "Bash(bundle install *)",
       "Bash(bin/rails generate *)",
       "Bash(bundle exec *)",
-      "Bash(RUBYOPT=\"-EUTF-8\" bundle exec rspec spec/models --format documentation)"
+      "Bash(RUBYOPT=\"-EUTF-8\" bundle exec rspec spec/models --format documentation)",
+      "Bash(RUBYOPT=\"-EUTF-8\" bundle exec rspec spec/requests --format documentation)",
+      "Bash(RUBYOPT=\"-EUTF-8\" bundle exec rspec spec/models spec/requests)"
     ]
   }
 }

--- a/spec/requests/boards_spec.rb
+++ b/spec/requests/boards_spec.rb
@@ -1,0 +1,103 @@
+require 'rails_helper'
+
+RSpec.describe 'Boards', type: :request do
+  let(:user)       { create(:user) }
+  let(:other_user) { create(:user) }
+  let(:board)      { create(:board, user: user) }
+
+  describe '未ログインのアクセス' do
+    it 'GET /boards はログイン画面にリダイレクト' do
+      get boards_path
+      expect(response).to redirect_to(new_user_session_path)
+    end
+
+    it 'GET /boards/:id はログイン画面にリダイレクト' do
+      get board_path(board)
+      expect(response).to redirect_to(new_user_session_path)
+    end
+
+    it 'GET /boards/new はログイン画面にリダイレクト' do
+      get new_board_path
+      expect(response).to redirect_to(new_user_session_path)
+    end
+  end
+
+  describe 'ログイン済みのアクセス' do
+    before { sign_in user }
+
+    describe 'GET /boards' do
+      it '200 OK を返す' do
+        get boards_path
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    describe 'GET /boards/:id' do
+      it '200 OK を返す' do
+        get board_path(board)
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    describe 'POST /boards' do
+      context '正常な値の場合' do
+        it 'ボードが作成されルートにリダイレクト' do
+          expect {
+            post boards_path, params: { board: { title: '新しいボード', content: '説明' } }
+          }.to change(Board, :count).by(1)
+          expect(response).to redirect_to(root_path)
+        end
+      end
+
+      context '不正な値の場合' do
+        it 'ボードが作成されず 422 を返す' do
+          expect {
+            post boards_path, params: { board: { title: '', content: '' } }
+          }.not_to change(Board, :count)
+          expect(response).to have_http_status(:unprocessable_entity)
+        end
+      end
+    end
+
+    describe 'PATCH /boards/:id' do
+      context '自分のボードの場合' do
+        it '更新できルートにリダイレクト' do
+          patch board_path(board), params: { board: { title: '更新タイトル', content: '更新内容' } }
+          expect(board.reload.title).to eq '更新タイトル'
+          expect(response).to redirect_to(root_path)
+        end
+      end
+
+      context '他人のボードの場合' do
+        it 'ルートにリダイレクトされ更新できない' do
+          other_board = create(:board, user: other_user, title: '元のタイトル')
+          patch board_path(other_board), params: { board: { title: '書き換え' } }
+          expect(other_board.reload.title).to eq '元のタイトル'
+          expect(response).to redirect_to(root_path)
+        end
+      end
+    end
+
+    describe 'DELETE /boards/:id' do
+      context '自分のボードの場合' do
+        it '削除できルートにリダイレクト' do
+          board
+          expect {
+            delete board_path(board)
+          }.to change(Board, :count).by(-1)
+          expect(response).to redirect_to(root_path)
+        end
+      end
+
+      context '他人のボードの場合' do
+        it '削除できない' do
+          other_board = create(:board, user: other_user)
+          expect {
+            delete board_path(other_board)
+          }.not_to change(Board, :count)
+          expect(response).to redirect_to(root_path)
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/comments_spec.rb
+++ b/spec/requests/comments_spec.rb
@@ -1,0 +1,81 @@
+require 'rails_helper'
+
+RSpec.describe 'Comments', type: :request do
+  let(:user)       { create(:user) }
+  let(:other_user) { create(:user) }
+  let(:board)      { create(:board, user: user) }
+  let(:task)       { create(:task, user: user, board: board) }
+  let(:comment)    { create(:comment, user: user, task: task) }
+
+  describe '未ログインのアクセス' do
+    it 'GET /tasks/:task_id/comments/new はログイン画面にリダイレクト' do
+      get new_task_comment_path(task)
+      expect(response).to redirect_to(new_user_session_path)
+    end
+  end
+
+  describe 'ログイン済みのアクセス' do
+    before { sign_in user }
+
+    describe 'POST /tasks/:task_id/comments' do
+      context '正常な値の場合' do
+        it 'コメントが作成されタスク詳細にリダイレクト' do
+          expect {
+            post task_comments_path(task), params: { comment: { content: 'コメント内容' } }
+          }.to change(Comment, :count).by(1)
+          expect(response).to redirect_to(board_task_path(task.board, task))
+        end
+      end
+
+      context '不正な値の場合' do
+        it 'コメントが作成されず 422 を返す' do
+          expect {
+            post task_comments_path(task), params: { comment: { content: '' } }
+          }.not_to change(Comment, :count)
+          expect(response).to have_http_status(:unprocessable_entity)
+        end
+      end
+    end
+
+    describe 'PATCH /tasks/:task_id/comments/:id' do
+      context '自分のコメントの場合' do
+        it '更新できタスク詳細にリダイレクト' do
+          patch task_comment_path(task, comment), params: { comment: { content: '更新コメント' } }
+          expect(comment.reload.content).to eq '更新コメント'
+          expect(response).to redirect_to(board_task_path(task.board, task))
+        end
+      end
+
+      context '他人のコメントの場合' do
+        it '更新できずタスク詳細にリダイレクト' do
+          other_comment = create(:comment, user: other_user, task: task, content: '元のコメント')
+          patch task_comment_path(task, other_comment), params: { comment: { content: '書き換え' } }
+          expect(other_comment.reload.content).to eq '元のコメント'
+          expect(response).to redirect_to(board_task_path(task.board, task))
+        end
+      end
+    end
+
+    describe 'DELETE /tasks/:task_id/comments/:id' do
+      context '自分のコメントの場合' do
+        it '削除できタスク詳細にリダイレクト' do
+          comment
+          expect {
+            delete task_comment_path(task, comment)
+          }.to change(Comment, :count).by(-1)
+          expect(response).to redirect_to(board_task_path(task.board, task))
+        end
+      end
+
+      context '他人のコメントの場合' do
+        it '削除できない' do
+          other_comment = create(:comment, user: other_user, task: task)
+          expect {
+            delete task_comment_path(task, other_comment)
+          }.not_to change(Comment, :count)
+          expect(response).to redirect_to(board_task_path(task.board, task))
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/home_spec.rb
+++ b/spec/requests/home_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe 'Home', type: :request do
+  describe 'GET /' do
+    context '未ログインの場合' do
+      it 'ログイン画面にリダイレクトされる' do
+        get root_path
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+
+    context 'ログイン済みの場合' do
+      it '200 OK を返す' do
+        sign_in create(:user)
+        get root_path
+        expect(response).to have_http_status(:ok)
+      end
+    end
+  end
+end

--- a/spec/requests/profiles_spec.rb
+++ b/spec/requests/profiles_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+RSpec.describe 'Profiles', type: :request do
+  let(:user) { create(:user) }
+
+  describe '未ログインのアクセス' do
+    it 'GET /profile はログイン画面にリダイレクト' do
+      get profile_path
+      expect(response).to redirect_to(new_user_session_path)
+    end
+
+    it 'GET /profile/edit はログイン画面にリダイレクト' do
+      get edit_profile_path
+      expect(response).to redirect_to(new_user_session_path)
+    end
+  end
+
+  describe 'ログイン済みのアクセス' do
+    before { sign_in user }
+
+    describe 'GET /profile' do
+      it '200 OK を返す' do
+        get profile_path
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    describe 'GET /profile/edit' do
+      it '200 OK を返す' do
+        get edit_profile_path
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    describe 'PUT /profile' do
+      context '正常な値の場合' do
+        it 'プロフィールが更新されルートにリダイレクト' do
+          put profile_path, params: { profile: { nickname: '新ニックネーム' } }
+          expect(user.reload.profile.nickname).to eq '新ニックネーム'
+          expect(response).to redirect_to(profile_path)
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/tasks_spec.rb
+++ b/spec/requests/tasks_spec.rb
@@ -1,0 +1,95 @@
+require 'rails_helper'
+
+RSpec.describe 'Tasks', type: :request do
+  let(:user)       { create(:user) }
+  let(:other_user) { create(:user) }
+  let(:board)      { create(:board, user: user) }
+  let(:task)       { create(:task, user: user, board: board) }
+
+  describe '未ログインのアクセス' do
+    it 'GET /boards/:board_id/tasks/:id はログイン画面にリダイレクト' do
+      get board_task_path(board, task)
+      expect(response).to redirect_to(new_user_session_path)
+    end
+  end
+
+  describe 'ログイン済みのアクセス' do
+    before { sign_in user }
+
+    describe 'GET /boards/:board_id/tasks/:id' do
+      it '200 OK を返す' do
+        get board_task_path(board, task)
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    describe 'POST /boards/:board_id/tasks' do
+      context '正常な値の場合' do
+        it 'タスクが作成されボード詳細にリダイレクト' do
+          expect {
+            post board_tasks_path(board), params: {
+              task: { title: '新タスク', content: '内容', priority: 'high' }
+            }
+          }.to change(Task, :count).by(1)
+          expect(response).to redirect_to(board_path(board))
+        end
+      end
+
+      context '不正な値の場合' do
+        it 'タスクが作成されず 422 を返す' do
+          expect {
+            post board_tasks_path(board), params: {
+              task: { title: '', content: '' }
+            }
+          }.not_to change(Task, :count)
+          expect(response).to have_http_status(:unprocessable_entity)
+        end
+      end
+    end
+
+    describe 'PATCH /boards/:board_id/tasks/:id' do
+      context '自分のタスクの場合' do
+        it '更新できタスク詳細にリダイレクト' do
+          patch board_task_path(board, task), params: {
+            task: { title: '更新タイトル', content: '更新内容' }
+          }
+          expect(task.reload.title).to eq '更新タイトル'
+          expect(response).to redirect_to(board_task_path(board, task))
+        end
+      end
+
+      context '他人のタスクの場合' do
+        it '更新できずタスク詳細にリダイレクト' do
+          other_task = create(:task, user: other_user, board: board, title: '元のタイトル')
+          patch board_task_path(board, other_task), params: {
+            task: { title: '書き換え', content: '書き換え' }
+          }
+          expect(other_task.reload.title).to eq '元のタイトル'
+          expect(response).to redirect_to(board_task_path(board, other_task))
+        end
+      end
+    end
+
+    describe 'DELETE /boards/:board_id/tasks/:id' do
+      context '自分のタスクの場合' do
+        it '削除できボード詳細にリダイレクト' do
+          task
+          expect {
+            delete board_task_path(board, task)
+          }.to change(Task, :count).by(-1)
+          expect(response).to redirect_to(board_path(board))
+        end
+      end
+
+      context '他人のタスクの場合' do
+        it '削除できない' do
+          other_task = create(:task, user: other_user, board: board)
+          expect {
+            delete board_task_path(board, other_task)
+          }.not_to change(Task, :count)
+          expect(response).to redirect_to(board_task_path(board, other_task))
+        end
+      end
+    end
+  end
+end

--- a/spec/support/devise.rb
+++ b/spec/support/devise.rb
@@ -1,0 +1,3 @@
+RSpec.configure do |config|
+  config.include Devise::Test::IntegrationHelpers, type: :request
+end


### PR DESCRIPTION
- Devise の sign_in ヘルパーを Request Spec で使えるよう spec/support/devise.rb を追加
- 未ログイン時に全ページがログイン画面へリダイレクトされることを確認
- Board / Task / Comment の作成・更新・削除が正常に動作することを確認
- 他人の Board / Task / Comment を更新・削除できないことを確認
- バリデーションエラー時に 422 が返り件数が増えないことを確認
- Profile の表示・編集・更新が正しく動作することを確認